### PR TITLE
fixes gizmodo.com content fetching

### DIFF
--- a/gizmodo.com.txt
+++ b/gizmodo.com.txt
@@ -1,5 +1,5 @@
 #body: //div[@class="post-body" or contains(@class, 'illustration top')]
-body: //div[contains(@class, 'image-annotation-box') or contains(@class, 'post-content')]
+body: //div[contains(@class, 'image-annotation-box') or contains(@class, 'post-content')] | //p[@class='first-text'] | //p
 #author: (//cite//span[@class="plus-icon"])[1]
 author: //span[contains(@class, 'display-name')]
 date: //span[@class="date"]
@@ -11,3 +11,4 @@ http_header(user-agent): PHP/5.3
 test_url: http://gizmodo.com/5880147/kuhn-rikon-improves-their-spice-grinder-with-grade-school-science
 test_url: http://gizmodo.com/what-van-goghs-paintings-would-look-like-if-they-came-874035680
 test_url: http://gizmodo.com/vip.xml
+test_url: http://gizmodo.com/there-are-some-super-shady-things-in-oculus-rifts-terms-1768678169


### PR DESCRIPTION
analog to lifehacker