### PR TITLE
Configuration for monde-diplomatique.fr

### DIFF
--- a/monde-diplomatique.fr.txt
+++ b/monde-diplomatique.fr.txt
@@ -1,0 +1,19 @@
+title://h1[@class="h1"]
+body: //div[@class="contenu-principal"]/div[@class="texte"]
+
+requires_login: yes
+
+login_uri: https://lecteurs.mondediplo.net/?page=connexion
+login_username_field: email
+login_password_field: mot_de_passe
+
+login_extra_fields: page=connexion
+login_extra_fields: formulaire_action=identification_lecteur
+login_extra_fields: formulaire_action_args=@=xpath("//form//input[@name='formulaire_action_args']", request_html(config.getLoginUri()))
+login_extra_fields: retour=http://www.monde-diplomatique.fr/
+login_extra_fields: site_distant=http://www.monde-diplomatique.fr/
+login_extra_fields: valider=valider
+
+not_logged_in_xpath: //div[@id="paywall"]
+
+test_url: http://blog.mondediplo.net/2017-01-13-Les-vrais-responsables-des-fausses-nouvelles


### PR DESCRIPTION
The title says most of it. It includes paywall configuration.

It uses the expression language to get the value of a login field from the login form itself. It uses `request_html` and `xpath` functions, that request an uri and return a value from an xpath query.

Expression language (and extra_fields key/value support) are implemented in https://github.com/bdunogier/guzzle-site-authenticator/pull/14. It itself depends on https://github.com/wallabag/wallabag/issues/2751, that improves the extensibility of the http client service definition.

But with both of those, it works like a charm here (I have an account for testing, but I don't know how that works).