### PR TITLE
Paywall configuration for lemonde.fr

### DIFF
--- a/lemonde.fr.txt
+++ b/lemonde.fr.txt
@@ -8,13 +8,19 @@ date: //time[@itemprop='dateModified']/@datetime
 # Publication date
 date: //time[@itemprop='datePublished']/@datetime
 
-
 body: //div[@id='articleBody']
 
 # Remove the insane "conjugaison.lemonde.fr" links:
 find_string: <a target='_blank' onclick='return false;' class='lien_interne conjug'
-replace_string: <input type='hidden' style='display:none;' 
+replace_string: <input type='hidden' style='display:none;'
 
 prune: no
 
 test_url: http://www.lemonde.fr/economie/article/2011/07/05/moody-s-abaisse-la-note-du-portugal-de-quatre-crans_1545237_3234.html
+
+requires_login: true
+login_uri: https://secure.lemonde.fr/sfuser/connexion
+login_username_field: connection[mail]
+login_password_field: connection[password]
+login_extra_fields: connection[_token]=@=xpath('//form[@name="connection"]/input[@name="connection[_token]"]', request_html('https://secure.lemonde.fr/sfuser/connexion'))
+login_extra_fields: connection[stay_connected]=1


### PR DESCRIPTION
Pushing to this upstream as I don't believe that this custom configuration belongs with the original repo.

Adds paywall config for lemonde.fr. But it doesn't "really" work, because of how their paywall is implemented. If you request `lemonde.fr`, you will always get the truncated version. If you request `abonnes.lemonde.fr`, you will always get the full version. Even if you don't have an account.

Unless graby supports some kind of string substitution for the URL, then the only solution is to use the `abonnes.lemonfr.fr` url.