### PR TITLE
Update mediapart: add date and author

### DIFF
--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -2,7 +2,7 @@ title://h1[@class="title"]
 body://section[@class="global-wrapper"]//div[@class="page-pane"]
 
 date: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//time
-author: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//author
+author: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//a[@class='journalist']
 
 single_page_link: //link[@rel="canonical"]
 

--- a/mediapart.fr.txt
+++ b/mediapart.fr.txt
@@ -1,6 +1,9 @@
 title://h1[@class="title"]
 body://section[@class="global-wrapper"]//div[@class="page-pane"]
 
+date: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//time
+author: //div[contains(concat(' ',normalize-space(@class),' '),' author ')]//author
+
 single_page_link: //link[@rel="canonical"]
 
 requires_login: yes


### PR DESCRIPTION
- Date is OK
- Author is OK for the 1st author, but it does not grab several authors: I don't know how to do that. Could you help me?

Test link with 2 authors: https://www.mediapart.fr/journal/france/131217/affaire-urvoas-ce-que-cache-thierry-solere

I'm updating mediapart here, as there's already a paywall. What should I do? (here or fivefilters/ftr-site-config ?)