### PR TITLE
Update abonnes.lemonde.fr.txt

### DIFF
--- a/abonnes.lemonde.fr.txt
+++ b/abonnes.lemonde.fr.txt
@@ -1,7 +1,6 @@
 title: //h1
 
 # We can have multiple authors
-author: //span[@id='publisher']
 author: //a[@class='auteur']
 
 # Last edition date (if any)
@@ -9,7 +8,7 @@ date: //time[@itemprop='dateModified']/@datetime
 # Publication date
 date: //time[@itemprop='datePublished']/@datetime
 
-
+# Body
 body: //div[@id='articleBody']|//section[@class='contenu']//div[@class='texte']
 
 # Remove highlighted quotes


### PR DESCRIPTION
Several authors: there are duplicates:
- `author: //span[@id='publisher']` was not necessary (and it's not present in `lemonde.fr.txt`)
- it seems that the standard parser also recognizes the authors, leading to duplication: "Marie Charrel, Marie de Vergès, Elise Barthet, Marie Charrel, Marie de Vergès et Elise Barthet" (for http://abonnes.lemonde.fr/economie/article/2017/11/24/la-zone-euro-renoue-avec-une-croissance-solide_5219697_3234.html): how to keep only "Marie Charrel, Marie de Vergès, Elise Barthet" (the part grabbed by `author: //a[@class='auteur']`) ?

Other remaining issue: last modified date is not the right one: it grabs `05 Dec 2017` instead of `25 Nov 2017`

Same as mediapart: as there's a paywall, I don't know where to push the modification.
