### PR TITLE
Sanitize more of the embed iframe from youtube

### DIFF
--- a/youtube.com.txt
+++ b/youtube.com.txt
@@ -1,11 +1,18 @@
 title: //title
+# This site config will parse the XML pointed to by the 'single_page_link' by extracting
+# the embed iframe using find_string/replace_string
 body: //iframe
 
+# Do minimal sanitization to make the iframe accessible via xpath
 find_string: <html>&lt;iframe 
 replace_string: <iframe id="video" 
 
 find_string: &gt;&lt;/iframe&gt;</html>
 replace_string: ></iframe>
+
+# Make all the properties of the iframe use regular encoding for quotes to avoid corruption
+find_string: &quot;
+replace_string: '
 
 single_page_link: //link[@type='text/xml+oembed']
 


### PR DESCRIPTION
Currently, when you try to scrape a youtube video with this via wallabag, the presence of url encoded quotes in the value of the iframe's `src` property is corrupting the rendered link.  An extra `https://www.youtube.com%20` is being inserted in said property at some point in the process.  This can be reproduced by having wallabag try to archive any youtube video (such as the one in this site config).

This change will make it so that the url encoded quotes are replaced with ASCII quotes, which is fixing the problem on my end.  I'm not sure if the behavior I'm seeing implies another bug somewhere in this process, or if I should be looking at another project, but as the intent of the site config appears to be to parse the iframe as if it were HTML, this seems like a needed fix either way.

Please push your site_config changes at fivefilters/ftr-site-config instead.
I regularly merge the upstream in that repo (so you don't need to duplicate your effort).
